### PR TITLE
Show cancelled cards when Second Chance activates

### DIFF
--- a/src/components/CardVisual/CardVisual.jsx
+++ b/src/components/CardVisual/CardVisual.jsx
@@ -1,6 +1,6 @@
 import styles from "./CardVisual.module.css";
 
-export default function CardVisual({ type, value, small, dimmed, highlight }) {
+export default function CardVisual({ type, value, small, dimmed, highlight, cancelled }) {
   const typeClass = type === "modifier" ? styles.modifier
     : type === "action" ? styles.action
     : styles.number;
@@ -11,7 +11,7 @@ export default function CardVisual({ type, value, small, dimmed, highlight }) {
 
   return (
     <div
-      className={`${styles.card} ${typeClass} ${small ? styles.small : ""} ${dimmed ? styles.dimmed : ""} ${highlight ? styles.highlight : ""}`}
+      className={`${styles.card} ${typeClass} ${small ? styles.small : ""} ${dimmed ? styles.dimmed : ""} ${highlight ? styles.highlight : ""} ${cancelled ? styles.cancelled : ""}`}
       style={bgStyle}
     >
       {value}

--- a/src/components/CardVisual/CardVisual.module.css
+++ b/src/components/CardVisual/CardVisual.module.css
@@ -59,6 +59,29 @@
   box-shadow: 0 0 0 2px var(--accent2), 0 2px 8px rgba(0,0,0,0.2);
 }
 
+.cancelled {
+  opacity: 0.4;
+  position: relative;
+  overflow: hidden;
+}
+
+.cancelled::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    to top right,
+    transparent calc(50% - 1.5px),
+    rgba(255, 255, 255, 0.7) calc(50% - 1.5px),
+    rgba(255, 255, 255, 0.7) calc(50% + 1.5px),
+    transparent calc(50% + 1.5px)
+  );
+  pointer-events: none;
+}
+
 @keyframes cardIn {
   from {
     opacity: 0;

--- a/src/components/PlayRound/PlayRound.jsx
+++ b/src/components/PlayRound/PlayRound.jsx
@@ -32,12 +32,16 @@ export default function PlayRound() {
   const getPlayerName = (pid) => game.players.find(p => p.id === pid)?.name || "?";
 
   // Build allPlayerData for bust calc (matches deckUtils shape)
+  // Include cancelled cards so remaining-card counts stay accurate
   const allPlayerData = {};
   for (const [pid, hand] of Object.entries(pr.playerHands)) {
+    const cancelledNumbers = (hand.cancelledCards || []).filter(c => c.type === "number").map(c => c.value);
+    const cancelledModifiers = (hand.cancelledCards || []).filter(c => c.type === "modifier").map(c => c.value);
+    const cancelledActions = (hand.cancelledCards || []).filter(c => c.type === "action").map(c => c.value);
     allPlayerData[pid] = {
-      numberCards: hand.numberCards,
-      modifiers: hand.modifiers,
-      actions: hand.actions,
+      numberCards: [...hand.numberCards, ...cancelledNumbers],
+      modifiers: [...hand.modifiers, ...cancelledModifiers],
+      actions: [...hand.actions, ...cancelledActions],
     };
   }
 
@@ -176,7 +180,10 @@ export default function PlayRound() {
               {hand.actions.map((a, i) => (
                 <CardVisual key={`a-${i}`} type="action" value={a} dimmed={busted} />
               ))}
-              {hand.numberCards.length === 0 && hand.modifiers.length === 0 && hand.actions.length === 0 && (
+              {(hand.cancelledCards || []).map((c, i) => (
+                <CardVisual key={`x-${i}`} type={c.type} value={c.value} cancelled />
+              ))}
+              {hand.numberCards.length === 0 && hand.modifiers.length === 0 && hand.actions.length === 0 && !(hand.cancelledCards || []).length && (
                 <div className={styles.noCards}>No cards</div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- When Second Chance saves from bust, the duplicate number card and consumed Second Chance action now remain visible as cancelled (dimmed + diagonal strikethrough) instead of being silently removed
- Gifted Second Chance cards are moved from the source player's card list to the recipient's, so the card appears where it belongs
- Cancelled cards are included in deck tracking and bust probability calculations for accuracy

## Test plan
- [ ] Draw Second Chance, then draw a duplicate number — both cards should appear cancelled in hand
- [ ] Draw two Second Chances — second triggers gift UI, recipient should show the card in their list
- [ ] Bust calculator (cheater mode) should still be accurate after Second Chance activates
- [ ] Deck tracker counts should remain correct across rounds with cancelled cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)