### PR TITLE
Add computer players to Play Mode (FLI-6)

### DIFF
--- a/src/components/PlayGameScreen/PlayGameScreen.jsx
+++ b/src/components/PlayGameScreen/PlayGameScreen.jsx
@@ -109,6 +109,7 @@ export default function PlayGameScreen() {
                   <div className={styles.playerName}>
                     {p.name}
                     {isDealer && <span className={styles.dealerBadge}>D</span>}
+                    {p.isComputer && <span className={styles.cpuBadge}>CPU</span>}
                   </div>
                   {lastResult && (
                     <div className={styles.playerLastRound}>

--- a/src/components/PlayGameScreen/PlayGameScreen.module.css
+++ b/src/components/PlayGameScreen/PlayGameScreen.module.css
@@ -119,6 +119,18 @@
   font-size: 11px;
 }
 
+.cpuBadge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: rgba(255, 179, 71, 0.15);
+  color: var(--accent);
+  font-family: 'Fredoka', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
 .playerLastRound {
   font-size: 12px;
   color: var(--text-dim);

--- a/src/components/PlayRound/PlayRound.module.css
+++ b/src/components/PlayRound/PlayRound.module.css
@@ -315,6 +315,47 @@
   }
 }
 
+.cpuBadge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: rgba(255, 179, 71, 0.15);
+  color: var(--accent);
+  font-family: 'Fredoka', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.cpuThinking {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: 'Fredoka', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent);
+  margin-top: 8px;
+  padding: 6px 0;
+}
+
+.thinkingDot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: thinkPulse 1.2s ease-in-out infinite;
+}
+
+.thinkingDot:nth-child(2) { animation-delay: 0.2s; }
+.thinkingDot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes thinkPulse {
+  0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1.2); }
+}
+
 @media (max-width: 400px) {
   .cardRow { gap: 4px; }
 }

--- a/src/components/SetupScreen/SetupScreen.jsx
+++ b/src/components/SetupScreen/SetupScreen.jsx
@@ -17,7 +17,15 @@ export default function SetupScreen() {
 
   const addPlayer = () => {
     if (game.players.length >= MAX_PLAYERS) return;
-    updateGame({ players: [...game.players, { id: uid(), name: "" }] });
+    updateGame({ players: [...game.players, { id: uid(), name: "", isComputer: false }] });
+  };
+
+  const addCpu = () => {
+    if (game.players.length >= MAX_PLAYERS) return;
+    const cpuCount = game.players.filter(p => p.isComputer).length;
+    updateGame({
+      players: [...game.players, { id: uid(), name: `CPU ${cpuCount + 1}`, isComputer: true }],
+    });
   };
 
   const startGame = () => {
@@ -61,7 +69,7 @@ export default function SetupScreen() {
       </p>
 
       {game.players.map((p, i) => (
-        <div key={p.id} className={styles.playerInputRow}>
+        <div key={p.id} className={`${styles.playerInputRow} ${p.isComputer ? styles.cpuRow : ""}`}>
           <div className={styles.playerNum}>{i + 1}</div>
           <input
             value={p.name}
@@ -70,12 +78,13 @@ export default function SetupScreen() {
               players[i] = { ...players[i], name: e.target.value };
               updateGame({ players });
             }}
-            placeholder={`Player ${i + 1}`}
+            placeholder={p.isComputer ? `CPU ${i + 1}` : `Player ${i + 1}`}
             autoFocus={i === game.players.length - 1}
             onKeyDown={e => {
               if (e.key === "Enter") addPlayer();
             }}
           />
+          {p.isComputer && <span className={styles.cpuBadge}>CPU</span>}
           {game.players.length > 2 && (
             <button className={styles.removeBtn} onClick={() => {
               updateGame({ players: game.players.filter((_, j) => j !== i) });
@@ -90,9 +99,16 @@ export default function SetupScreen() {
 
       <div className={styles.setupActions}>
         {game.players.length < MAX_PLAYERS && (
-          <button className="btn btn-secondary btn-small" onClick={addPlayer}>
-            + Add Player
-          </button>
+          <>
+            <button className="btn btn-secondary btn-small" onClick={addPlayer}>
+              + Add Player
+            </button>
+            {isPlayMode && (
+              <button className={`btn btn-secondary btn-small ${styles.addCpuBtn}`} onClick={addCpu}>
+                + Add CPU
+              </button>
+            )}
+          </>
         )}
         <button
           className="btn btn-primary btn-small"

--- a/src/components/SetupScreen/SetupScreen.module.css
+++ b/src/components/SetupScreen/SetupScreen.module.css
@@ -102,6 +102,32 @@
   font-weight: 600;
 }
 
+.cpuRow {
+  border-left: 3px solid var(--accent);
+}
+
+.cpuRow input {
+  border-color: rgba(255, 179, 71, 0.3);
+}
+
+.cpuBadge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: rgba(255, 179, 71, 0.15);
+  color: var(--accent);
+  font-family: 'Fredoka', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.addCpuBtn {
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+}
+
 .maxWarning {
   color: var(--accent);
   font-size: 12px;

--- a/src/utils/computerStrategy.js
+++ b/src/utils/computerStrategy.js
@@ -1,0 +1,96 @@
+import { calculateBustChance } from "./bustCalculator";
+import { calculateScore } from "./scoring";
+import { getPlayerTotal } from "./helpers";
+
+/**
+ * Decide whether a computer player should hit or stand.
+ * Returns "hit" or "stand".
+ */
+export function decideAction({ playerId, hand, dealt, allPlayerData, game }) {
+  // Always hit with 0 cards
+  if (hand.numberCards.length === 0 && hand.modifiers.length === 0 && hand.actions.length === 0) {
+    return "hit";
+  }
+
+  const { bustChance } = calculateBustChance(hand.numberCards, dealt, allPlayerData);
+  const result = calculateScore(hand.numberCards, hand.modifiers, false);
+  const myTotal = getPlayerTotal(game, playerId);
+
+  // Base threshold: stand if bust chance >= threshold
+  let threshold = 50;
+
+  // Card count modifier: chase Flip 7
+  const cardCount = hand.numberCards.length + hand.modifiers.length + hand.actions.length;
+  if (cardCount >= 6) threshold += 20;
+  else if (cardCount >= 5) threshold += 10;
+
+  // Hand score modifier
+  if (result.total <= 5) threshold += 15;
+  else if (result.total >= 30) threshold -= 10;
+
+  // Game position modifiers
+  const opponents = game.players.filter(p => p.id !== playerId);
+  if (opponents.length > 0) {
+    const opponentTotals = opponents.map(p => getPlayerTotal(game, p.id));
+    const maxOpponent = Math.max(...opponentTotals);
+
+    // Behind: play more aggressively
+    if (maxOpponent - myTotal > 50) threshold += 15;
+    // Ahead: play more conservatively
+    if (myTotal - maxOpponent > 30) threshold -= 10;
+
+    // Opponent close to winning
+    if (opponentTotals.some(t => t >= 170)) threshold += 12;
+  }
+
+  // Second Chance shield: play more aggressively
+  if (hand.hasSecondChance) threshold += 15;
+
+  // Clamp threshold
+  threshold = Math.max(20, Math.min(90, threshold));
+
+  return bustChance >= threshold ? "stand" : "hit";
+}
+
+/**
+ * Choose a target for Flip Three.
+ * Picks the opponent with the highest cumulative score (punish the leader).
+ */
+export function chooseFlipThreeTarget(chooserId, playingPlayerIds, game) {
+  const opponents = playingPlayerIds.filter(pid => pid !== chooserId);
+  if (opponents.length === 0) return chooserId;
+
+  let bestTarget = opponents[0];
+  let bestScore = getPlayerTotal(game, opponents[0]);
+
+  for (let i = 1; i < opponents.length; i++) {
+    const score = getPlayerTotal(game, opponents[i]);
+    if (score > bestScore) {
+      bestScore = score;
+      bestTarget = opponents[i];
+    }
+  }
+
+  return bestTarget;
+}
+
+/**
+ * Choose a target for gifting a Second Chance.
+ * Gives to the opponent with the lowest cumulative score (least threatening).
+ */
+export function chooseSecondChanceTarget(eligiblePlayerIds, game) {
+  if (eligiblePlayerIds.length === 1) return eligiblePlayerIds[0];
+
+  let bestTarget = eligiblePlayerIds[0];
+  let bestScore = getPlayerTotal(game, eligiblePlayerIds[0]);
+
+  for (let i = 1; i < eligiblePlayerIds.length; i++) {
+    const score = getPlayerTotal(game, eligiblePlayerIds[i]);
+    if (score < bestScore) {
+      bestScore = score;
+      bestTarget = eligiblePlayerIds[i];
+    }
+  }
+
+  return bestTarget;
+}


### PR DESCRIPTION
## Summary
- Add AI-controlled computer players that auto-play turns using a bust probability strategy with modifiers for card count, hand score, game position, and shields
- New "Add CPU" button in setup screen (Play Mode only) with distinct amber styling and CPU badges
- CPU turns show animated "Thinking..." indicator with 800ms delay; keyboard shortcuts disabled during CPU turns
- Automatic target selection for Flip Three (punishes leader) and Second Chance (gifts to least threatening opponent)
- CPU badges displayed in both round view and between-rounds scoreboard

## Test plan
- [x] Create game with 2 humans + 2 CPUs — verify separate add buttons, auto-naming, CPU visual distinction
- [x] Play a round — verify CPU auto-plays with delay, "Thinking..." shows, Hit/Stand buttons hidden
- [ ] Trigger Flip Three on CPU turn — verify auto-target selection with "choosing" indicator
- [ ] Trigger Second Chance on CPU turn — verify auto-gift selection
- [x] Verify keyboard shortcuts (H/S) disabled during CPU turns but work for human turns
- [x] Verify CPU badges appear in round view and scoreboard
- [ ] Save/reload game — verify CPU players persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)