### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/flip7/',
   plugins: [react()],
   test: {
     globals: false,


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to auto-deploy to GitHub Pages on push to main
- Set Vite `base` to `/flip7/` for correct asset paths on GitHub Pages
- Enabled GitHub Pages (source: Actions) and made the repo public

Resolves FLI-7

## Test plan
- [x] Verify `npm run build` succeeds locally
- [ ] Merge PR and confirm the deploy workflow runs successfully
- [ ] Verify the app is accessible at https://lchoward.github.io/flip7/

🤖 Generated with [Claude Code](https://claude.com/claude-code)