### PR TITLE
Add How to Play tutorial carousel

### DIFF
--- a/src/components/HomeScreen/HomeScreen.jsx
+++ b/src/components/HomeScreen/HomeScreen.jsx
@@ -1,11 +1,13 @@
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useGame } from "../../context/GameContext";
 import { ACTIONS } from "../../context/gameReducer";
 import ConfirmDialog from "../ConfirmDialog/ConfirmDialog";
+import HowToPlay from "../HowToPlay/HowToPlay";
 import styles from "./HomeScreen.module.css";
 
 export default function HomeScreen() {
   const { game, dialog, dispatch } = useGame();
+  const [showHowToPlay, setShowHowToPlay] = useState(false);
 
   const startNewGame = () => {
     dispatch({ type: ACTIONS.START_NEW_GAME });
@@ -30,14 +32,14 @@ export default function HomeScreen() {
   // Keyboard shortcut: Enter = New Game
   useEffect(() => {
     const handleKey = (e) => {
-      if (dialog) return;
+      if (dialog || showHowToPlay) return;
       if (e.key === "Enter") {
         confirmNewGame();
       }
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [dialog, game]);
+  }, [dialog, game, showHowToPlay]);
 
   return (
     <>
@@ -59,9 +61,11 @@ export default function HomeScreen() {
               Continue Game
             </button>
           )}
+          <button className="btn btn-ghost" onClick={() => setShowHowToPlay(true)}>How to Play</button>
         </div>
       </div>
       {dialog && <ConfirmDialog {...dialog} />}
+      {showHowToPlay && <HowToPlay onClose={() => setShowHowToPlay(false)} />}
     </>
   );
 }

--- a/src/components/HowToPlay/HowToPlay.jsx
+++ b/src/components/HowToPlay/HowToPlay.jsx
@@ -1,0 +1,418 @@
+import { useState, useEffect, useRef } from "react";
+import styles from "./HowToPlay.module.css";
+
+const SLIDES = [
+  {
+    title: "Race to 200",
+    text: "Be the first player to reach 200 points across multiple rounds.",
+  },
+  {
+    title: "Hit or Stand",
+    text: "Each turn, draw cards to build your hand. Hit to draw another card, or Stand to lock in your points.",
+  },
+  {
+    title: "Stand",
+    subtitle: "Case 1",
+    text: "Locking in keeps your cards safe. You score the sum of your number cards.",
+  },
+  {
+    title: "Hit",
+    subtitle: "Case 2",
+    text: "Drawing another card can boost your score \u2014 but risk busting if you draw a duplicate!",
+  },
+  {
+    title: "Avoid Duplicates",
+    text: "Drawing a number you already have means you bust \u2014 scoring 0 for the round.",
+  },
+  {
+    title: "Flip 7!",
+    text: "Collect exactly 7 unique number cards without busting for a +15 point bonus!",
+  },
+  {
+    title: "Action Cards",
+    text: (
+      <ul className={styles.bulletList}>
+        <li><strong>Freeze:</strong> Ends your turn immediately</li>
+        <li><strong>Flip Three:</strong> Force any player to draw 3 cards, even yourself</li>
+        <li><strong>Second Chance:</strong> Protects you from one bust</li>
+      </ul>
+    ),
+  },
+  {
+    title: "Boost Your Score",
+    text: "Modifier cards add bonus points. +2 to +10 add flat points. x2 doubles only your number cards!",
+  },
+];
+
+function MiniCard({ value, className = "", style = {}, small }) {
+  return (
+    <div
+      className={`${styles.miniCard} ${small ? styles.miniCardSmall : ""} ${className}`}
+      style={style}
+    >
+      {value}
+    </div>
+  );
+}
+
+function numberColor(n) {
+  return `hsl(${n * 28}, 70%, 50%)`;
+}
+
+/* Slide 1 — Race to 200 */
+function Slide1() {
+  return (
+    <div className={styles.progressArea}>
+      <div className={styles.progressTrack}>
+        <div className={styles.progressFill} />
+      </div>
+      <div className={styles.milestones}>
+        <span>0</span>
+        <span>50</span>
+        <span>100</span>
+        <span>150</span>
+        <span className={styles.milestone200}>200</span>
+      </div>
+    </div>
+  );
+}
+
+/* Slide 2 — Hit or Stand */
+function Slide2() {
+  const cards = [3, 7, 11];
+  return (
+    <div className={styles.dealArea}>
+      <div className={styles.cardRow}>
+        {cards.map((n, i) => (
+          <MiniCard
+            key={n}
+            value={n}
+            className={styles.dealIn}
+            style={{
+              background: numberColor(n),
+              animationDelay: `${i * 0.25}s`,
+            }}
+          />
+        ))}
+      </div>
+      <div className={styles.mockButtons}>
+        <div className={`${styles.mockBtn} ${styles.mockHit}`}>Hit</div>
+        <div className={`${styles.mockBtn} ${styles.mockStand}`}>Stand</div>
+      </div>
+    </div>
+  );
+}
+
+/* Slide 3 — Stand (Case 1) */
+function Slide3() {
+  const cards = [3, 7, 11];
+  return (
+    <div className={styles.dealArea}>
+      <div className={styles.cardRow}>
+        {cards.map((n) => (
+          <MiniCard
+            key={n}
+            value={n}
+            style={{ background: numberColor(n) }}
+          />
+        ))}
+      </div>
+      <div className={styles.mockButtons}>
+        <div className={`${styles.mockBtn} ${styles.mockStand} ${styles.standPulse}`}>Stand</div>
+      </div>
+      <div className={styles.scoreLockedArea}>
+        <span className={styles.scoreLocked}>21 pts</span>
+        <span className={styles.lockIcon}>Locked in!</span>
+      </div>
+    </div>
+  );
+}
+
+/* Slide 4 — Hit (Case 2) */
+function Slide4() {
+  const baseCards = [3, 7, 11];
+  return (
+    <div className={styles.dealArea}>
+      <div className={styles.cardRow}>
+        {baseCards.map((n) => (
+          <MiniCard
+            key={n}
+            value={n}
+            style={{ background: numberColor(n) }}
+          />
+        ))}
+        <MiniCard
+          value={12}
+          className={styles.dealIn}
+          style={{
+            background: numberColor(12),
+            animationDelay: "0.6s",
+          }}
+        />
+      </div>
+      <div className={styles.scoreTransition}>
+        <span className={styles.scoreOld}>21</span>
+        <span className={styles.scoreArrow}>&rarr;</span>
+        <span className={styles.scoreNew}>33</span>
+      </div>
+    </div>
+  );
+}
+
+/* Slide 5 — Avoid Duplicates */
+function Slide5() {
+  const safeCards = [5, 9, 3];
+  return (
+    <div className={styles.bustArea}>
+      <div className={styles.bustHand}>
+        <div className={styles.bustDim} style={{ display: "flex", gap: 10 }}>
+          {safeCards.map((n, i) => (
+            <MiniCard
+              key={`safe-${n}`}
+              value={n}
+              className={styles.dealIn}
+              style={{
+                background: numberColor(n),
+                animationDelay: `${i * 0.25}s`,
+              }}
+            />
+          ))}
+          <MiniCard
+            value={5}
+            className={`${styles.dupeCard} ${styles.dupeHighlight}`}
+            style={{ background: numberColor(5) }}
+          />
+        </div>
+      </div>
+      <div className={styles.bustScoreRow}>
+        <span className={styles.bustBadge}>BUST!</span>
+        <div className={styles.scoreTransition}>
+          <span className={styles.scoreOld}>17</span>
+          <span className={styles.scoreArrow}>&rarr;</span>
+          <span className={styles.bustScoreZero}>0</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* Slide 6 — Flip 7 */
+function Slide6() {
+  const cards = [1, 4, 6, 8, 10, 2, 12];
+  const sum = cards.reduce((a, b) => a + b, 0);
+  return (
+    <div className={styles.flip7Area}>
+      <div className={styles.cardArc}>
+        {cards.map((n, i) => (
+          <MiniCard
+            key={n}
+            value={n}
+            small
+            className={styles.arcCard}
+            style={{
+              background: numberColor(n),
+              animationDelay: `${i * 0.3}s`,
+              transform: `rotate(${(i - 3) * 5}deg)`,
+            }}
+          />
+        ))}
+      </div>
+      <div className={styles.flip7Badge}>FLIP 7! +15</div>
+      <div className={styles.flip7Score}>
+        <span className={styles.scoreOld}>{sum}</span>
+        <span className={styles.scoreArrow}>+15 =</span>
+        <span className={styles.scoreNew}>{sum + 15}</span>
+      </div>
+    </div>
+  );
+}
+
+/* Slide 7 — Action Cards */
+function Slide7() {
+  const actions = [
+    { name: "\u2744\uFE0F", label: "Freeze" },
+    { name: "3x", label: "Flip Three" },
+    { name: "\u2764\uFE0F", label: "Second Chance" },
+  ];
+  return (
+    <div className={styles.actionArea}>
+      {actions.map((a, i) => (
+        <div
+          key={a.label}
+          className={styles.actionItem}
+          style={{ animationDelay: `${i * 0.3}s` }}
+        >
+          <MiniCard
+            value={a.name}
+            className={styles.actionCard}
+            style={{ fontSize: 20 }}
+          />
+          <span className={styles.actionLabel}>{a.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* Slide 8 — Boost Your Score */
+function Slide8() {
+  return (
+    <div className={styles.scoreArea}>
+      {/* Step 1: Base number cards → 11 */}
+      <div className={styles.scoreStep} style={{ animationDelay: "0s" }}>
+        <MiniCard value={3} style={{ background: numberColor(3) }} small />
+        <span className={styles.scorePlus}>+</span>
+        <MiniCard value={8} style={{ background: numberColor(8) }} small />
+        <span className={styles.scorePlus}>=</span>
+        <span className={styles.scoreDisplay}>11</span>
+      </div>
+      {/* Step 2: x2 doubles number cards → (3+8)x2 = 22 */}
+      <div className={styles.scoreStep} style={{ animationDelay: "0.8s" }}>
+        <span className={styles.scoreFormula}>(3 + 8)</span>
+        <MiniCard
+          value="x2"
+          className={`${styles.modifierCard} ${styles.slideInCard}`}
+          small
+          style={{ animationDelay: "0.8s" }}
+        />
+        <span className={styles.scorePlus}>=</span>
+        <span className={`${styles.scoreDisplay} ${styles.scoreChange}`} style={{ animationDelay: "1.2s" }}>
+          22
+        </span>
+      </div>
+      {/* Step 3: +4 modifier adds flat → 22+4 = 26 */}
+      <div className={styles.scoreStep} style={{ animationDelay: "1.6s" }}>
+        <span className={styles.scoreFormula}>22</span>
+        <span className={styles.scorePlus}>+</span>
+        <MiniCard
+          value="+4"
+          className={`${styles.modifierCard} ${styles.slideInCard}`}
+          small
+          style={{ animationDelay: "1.6s" }}
+        />
+        <span className={styles.scorePlus}>=</span>
+        <span className={`${styles.scoreDisplay} ${styles.scoreChange}`} style={{ animationDelay: "2s" }}>
+          26
+        </span>
+      </div>
+    </div>
+  );
+}
+
+const SLIDE_VISUALS = [Slide1, Slide2, Slide3, Slide4, Slide5, Slide6, Slide7, Slide8];
+
+export default function HowToPlay({ onClose }) {
+  const [current, setCurrent] = useState(0);
+  const touchRef = useRef(null);
+  const isLast = current === SLIDES.length - 1;
+  const isFirst = current === 0;
+
+  const goNext = () => {
+    if (!isLast) setCurrent((c) => c + 1);
+  };
+
+  const goPrev = () => {
+    if (!isFirst) setCurrent((c) => c - 1);
+  };
+
+  // Keyboard navigation + Escape
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === "Escape") onClose();
+      else if (e.key === "ArrowRight") goNext();
+      else if (e.key === "ArrowLeft") goPrev();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  });
+
+  // Body scroll lock
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  // Touch swipe
+  const onTouchStart = (e) => {
+    touchRef.current = e.touches[0].clientX;
+  };
+  const onTouchEnd = (e) => {
+    if (touchRef.current === null) return;
+    const diff = touchRef.current - e.changedTouches[0].clientX;
+    if (Math.abs(diff) > 50) {
+      if (diff > 0) goNext();
+      else goPrev();
+    }
+    touchRef.current = null;
+  };
+
+  const Visual = SLIDE_VISUALS[current];
+  const slide = SLIDES[current];
+
+  return (
+    <div
+      className={styles.overlay}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+        &times;
+      </button>
+
+      <div className={styles.carousel}>
+        <div className={styles.slide} key={current}>
+          {slide.subtitle && (
+            <span className={styles.slideSubtitle}>{slide.subtitle}</span>
+          )}
+          <h2 className={styles.slideTitle}>{slide.title}</h2>
+          <div className={styles.visual}>
+            <Visual />
+          </div>
+          <div className={styles.slideText}>{slide.text}</div>
+        </div>
+
+        <div className={styles.nav}>
+          <button
+            className={styles.navBtn}
+            onClick={goPrev}
+            disabled={isFirst}
+            aria-label="Previous slide"
+          >
+            &#8249;
+          </button>
+
+          <div className={styles.dots}>
+            {SLIDES.map((_, i) => (
+              <button
+                key={i}
+                className={`${styles.dot} ${i === current ? styles.dotActive : ""}`}
+                onClick={() => setCurrent(i)}
+                aria-label={`Go to slide ${i + 1}`}
+              />
+            ))}
+          </div>
+
+          {isLast ? (
+            <button
+              className="btn btn-primary btn-small"
+              onClick={onClose}
+              style={{ borderRadius: 50 }}
+            >
+              Got It!
+            </button>
+          ) : (
+            <button
+              className={styles.navBtn}
+              onClick={goNext}
+              aria-label="Next slide"
+            >
+              &#8250;
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HowToPlay/HowToPlay.module.css
+++ b/src/components/HowToPlay/HowToPlay.module.css
@@ -1,0 +1,637 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.25s ease-out;
+}
+
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 28px;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+  z-index: 2;
+}
+
+.closeBtn:hover {
+  color: var(--text);
+}
+
+.carousel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  max-width: 400px;
+  padding: 0 20px;
+}
+
+.slide {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 20px;
+  width: 100%;
+}
+
+.slideSubtitle {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-bottom: -12px;
+}
+
+.slideTitle {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.slideText {
+  font-size: 15px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  max-width: 320px;
+}
+
+.visual {
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  position: relative;
+}
+
+/* Bullet list for action cards */
+.bulletList {
+  list-style: none;
+  padding: 0;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bulletList li {
+  font-size: 14px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+.bulletList li::before {
+  content: "\2022";
+  color: var(--primary);
+  font-weight: 700;
+  margin-right: 8px;
+}
+
+.bulletList strong {
+  color: var(--text);
+}
+
+/* Navigation */
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: 32px;
+}
+
+.navBtn {
+  background: var(--surface2);
+  border: none;
+  color: var(--text);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  font-size: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s;
+}
+
+.navBtn:hover {
+  background: var(--primary-dim);
+}
+
+.navBtn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.navBtn:disabled:hover {
+  background: var(--surface2);
+}
+
+.dots {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--surface2);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.dotActive {
+  width: 24px;
+  background: var(--primary);
+}
+
+/* Mini cards shared style */
+.miniCard {
+  width: 44px;
+  height: 62px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Fredoka', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: #fff;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
+}
+
+.miniCardSmall {
+  width: 36px;
+  height: 50px;
+  font-size: 14px;
+  border-radius: 6px;
+}
+
+.modifierCard {
+  background: linear-gradient(135deg, #f0a030, #e08820);
+}
+
+.actionCard {
+  background: linear-gradient(135deg, #9b59b6, #8e44ad);
+}
+
+/* ======= Slide 1: Race to 200 ======= */
+.progressArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.progressTrack {
+  width: 100%;
+  max-width: 280px;
+  height: 28px;
+  background: var(--surface2);
+  border-radius: 14px;
+  position: relative;
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  border-radius: 14px;
+  background: linear-gradient(90deg, var(--primary), var(--accent));
+  animation: fillBar 2s ease-out forwards;
+  width: 0;
+}
+
+.milestones {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 280px;
+  margin-top: 8px;
+  font-family: 'Fredoka', sans-serif;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.milestone200 {
+  color: var(--primary);
+  font-weight: 700;
+  animation: glowPulse 1s ease-in-out 2s infinite alternate;
+}
+
+@keyframes fillBar {
+  0% { width: 0; }
+  100% { width: 100%; }
+}
+
+@keyframes glowPulse {
+  from { text-shadow: 0 0 4px rgba(0, 212, 170, 0.3); }
+  to { text-shadow: 0 0 12px rgba(0, 212, 170, 0.8); }
+}
+
+/* ======= Slide 2: Hit or Stand ======= */
+.dealArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.cardRow {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.dealIn {
+  opacity: 0;
+  animation: dealCard 0.4s ease-out forwards;
+}
+
+.mockButtons {
+  display: flex;
+  gap: 12px;
+}
+
+.mockBtn {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 20px;
+  border-radius: 50px;
+  border: none;
+  cursor: default;
+}
+
+.mockHit {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dim));
+  color: var(--bg);
+}
+
+.mockStand {
+  background: var(--surface2);
+  color: var(--text);
+  border: 2px solid var(--surface2);
+}
+
+@keyframes dealCard {
+  0% {
+    opacity: 0;
+    transform: scale(0.5) translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* ======= Slide 3: Stand ======= */
+.standPulse {
+  animation: standGlow 1s ease-in-out 0.5s infinite alternate;
+  border: 2px solid var(--primary) !important;
+  color: var(--primary) !important;
+}
+
+.scoreLockedArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  animation: fadeSlideIn 0.4s ease-out 0.8s forwards;
+}
+
+.scoreLocked {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.lockIcon {
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+@keyframes standGlow {
+  from { box-shadow: 0 0 4px rgba(0, 212, 170, 0.2); }
+  to { box-shadow: 0 0 16px rgba(0, 212, 170, 0.5); }
+}
+
+/* ======= Slide 4: Hit ======= */
+.scoreTransition {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: 'Fredoka', sans-serif;
+}
+
+.scoreOld {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+
+.scoreArrow {
+  font-size: 16px;
+  color: var(--text-dim);
+}
+
+.scoreNew {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary);
+  opacity: 0;
+  animation: scorePop 0.4s ease-out 1s forwards;
+}
+
+@keyframes scorePop {
+  0% { opacity: 0; transform: scale(0.7); }
+  60% { opacity: 1; transform: scale(1.15); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+/* ======= Slide 5: Avoid Duplicates ======= */
+.bustArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.bustHand {
+  display: flex;
+  gap: 10px;
+  position: relative;
+}
+
+.bustDim {
+  animation: dimHand 0.3s ease-out 1.8s forwards;
+}
+
+.dupeCard {
+  animation: dealCard 0.4s ease-out 1.2s forwards, bustShake 0.4s ease-out 1.6s;
+  opacity: 0;
+}
+
+.dupeHighlight {
+  box-shadow: 0 0 0 3px var(--accent2), 0 3px 12px rgba(0, 0, 0, 0.3) !important;
+}
+
+.bustScoreRow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.bustBadge {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--accent2);
+  opacity: 0;
+  animation: bustBadgePop 0.3s ease-out 2s forwards;
+}
+
+.bustScoreZero {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--accent2);
+  opacity: 0;
+  animation: scorePop 0.4s ease-out 2.2s forwards;
+}
+
+.bustScoreRow .scoreOld {
+  opacity: 0;
+  animation: fadeSlideIn 0.3s ease-out 2s forwards;
+}
+
+.bustScoreRow .scoreArrow {
+  opacity: 0;
+  animation: fadeSlideIn 0.3s ease-out 2s forwards;
+}
+
+.bustScoreRow .scoreTransition {
+  opacity: 0;
+  animation: fadeSlideIn 0.3s ease-out 2s forwards;
+}
+
+@keyframes bustShake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-6px); }
+  40% { transform: translateX(6px); }
+  60% { transform: translateX(-4px); }
+  80% { transform: translateX(4px); }
+}
+
+@keyframes bustBadgePop {
+  0% { opacity: 0; transform: scale(0.5); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes dimHand {
+  to { opacity: 0.4; }
+}
+
+/* ======= Slide 6: Flip 7 ======= */
+.flip7Area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.cardArc {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+
+.arcCard {
+  opacity: 0;
+  animation: dealCard 0.35s ease-out forwards;
+}
+
+.flip7Badge {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  opacity: 0;
+  animation: bustBadgePop 0.4s ease-out 2.6s forwards;
+}
+
+.flip7Score {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Fredoka', sans-serif;
+  opacity: 0;
+  animation: fadeSlideIn 0.4s ease-out 3s forwards;
+}
+
+.flip7Score .scoreOld {
+  font-size: 20px;
+}
+
+.flip7Score .scoreArrow {
+  font-size: 14px;
+}
+
+.flip7Score .scoreNew {
+  opacity: 1;
+  animation: none;
+}
+
+/* ======= Slide 7: Action Cards ======= */
+.actionArea {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-width: 300px;
+}
+
+.actionItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  opacity: 0;
+  animation: dealCard 0.4s ease-out forwards;
+  flex: 1;
+}
+
+.actionLabel {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.3;
+}
+
+/* ======= Slide 8: Boost Your Score ======= */
+.scoreArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.scorePlus {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 16px;
+  color: var(--text-dim);
+}
+
+.slideInCard {
+  opacity: 0;
+  animation: slideIn 0.4s ease-out forwards;
+}
+
+.scoreDisplay {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+  min-width: 40px;
+}
+
+.scoreChange {
+  animation: scoreChange 0.3s ease-out;
+}
+
+.scoreStep {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  opacity: 0;
+  animation: fadeSlideIn 0.4s ease-out forwards;
+}
+
+.scoreStep .scoreDisplay {
+  font-size: 22px;
+}
+
+.scoreFormula {
+  font-family: 'Fredoka', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+
+@keyframes slideIn {
+  0% {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scoreChange {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+
+@keyframes fadeSlideIn {
+  0% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Responsive */
+@media (max-width: 400px) {
+  .slideTitle {
+    font-size: 22px;
+  }
+
+  .slideText {
+    font-size: 14px;
+  }
+
+  .miniCard {
+    width: 38px;
+    height: 54px;
+    font-size: 16px;
+  }
+
+  .miniCardSmall {
+    width: 32px;
+    height: 44px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an 8-slide animated tutorial carousel accessible via a "How to Play" button on the HomeScreen
- Covers all game concepts: scoring to 200, hit/stand, busting, Flip 7 bonus, action cards, and modifier cards
- Each slide has CSS-animated visuals (card dealing, score transitions, bust shake, progress bar fill)
- Supports keyboard navigation (arrow keys, Escape), touch swipe, and dot indicators

## Test plan
- [x] Click "How to Play" on HomeScreen — overlay opens with slide 1
- [x] Navigate with left/right arrows, dots, keyboard, and swipe
- [x] Verify animations replay when navigating back and forth
- [x] Escape key and close button dismiss the overlay
- [x] "Got It!" button on last slide closes the overlay
- [x] Test on narrow viewport (375px) — no overflow
- [x] Verify Enter key shortcut for New Game is blocked while tutorial is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)