### PR TITLE
Fix bust % double-counting in play mode cheater view

### DIFF
--- a/src/components/PlayRound/PlayRound.jsx
+++ b/src/components/PlayRound/PlayRound.jsx
@@ -3,7 +3,6 @@ import { useGame } from "../../context/GameContext";
 import { ACTIONS } from "../../context/gameReducer";
 import { calculateScore } from "../../utils/scoring";
 import { calculateBustChance } from "../../utils/bustCalculator";
-import { flattenHandWithCancelled } from "../../utils/handUtils";
 import { decideAction, chooseFlipThreeTarget, chooseSecondChanceTarget } from "../../utils/computerStrategy";
 import { getPlayerTotal } from "../../utils/helpers";
 import CardVisual from "../CardVisual/CardVisual";
@@ -100,9 +99,7 @@ export default function PlayRound() {
         playerId: activePid,
         hand,
         dealt: getEffectiveDealtCards(),
-        allPlayerData: Object.fromEntries(
-          Object.entries(pr.playerHands).map(([pid, h]) => [pid, flattenHandWithCancelled(h)])
-        ),
+        allPlayerData: {},
         game,
       });
       if (action === "hit") {
@@ -123,11 +120,6 @@ export default function PlayRound() {
 
   const getPlayerName = (pid) => game.players.find(p => p.id === pid)?.name || "?";
   const isComputerPlayer = (pid) => game.players.find(p => p.id === pid)?.isComputer === true;
-
-  // Build allPlayerData for bust calc (includes cancelled cards for accurate remaining-card counts)
-  const allPlayerData = Object.fromEntries(
-    Object.entries(pr.playerHands).map(([pid, hand]) => [pid, flattenHandWithCancelled(hand)])
-  );
 
   const dealt = getEffectiveDealtCards();
 
@@ -319,7 +311,7 @@ export default function PlayRound() {
             )}
 
             {cheaterMode && hand.status === "playing" && hand.numberCards.length > 0 && dealt && (
-              <BustChanceBanner {...calculateBustChance(hand.numberCards, dealt, allPlayerData)} />
+              <BustChanceBanner {...calculateBustChance(hand.numberCards, dealt, {})} />
             )}
 
             {isActive && isComputerPlayer(pid) && (


### PR DESCRIPTION
## Summary
- `getEffectiveDealtCards()` already includes current round hands + cancelled cards, but `calculateBustChance` was also subtracting them via `allPlayerData`, causing current cards to be removed twice from the remaining count
- This made the denominator too low and the bust percentage too high
- Passes `{}` as `allPlayerData` since `dealt` already accounts for all in-play cards — fixes both the cheater banner display and CPU strategy decisions

## Test plan
- [ ] Start a play mode game with cheater mode on
- [ ] Verify the bust banner denominator matches the "X cards in deck" count shown at the top
- [ ] Verify CPU players still make reasonable hit/stand decisions

Closes FLI-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)